### PR TITLE
fix: 修复主题选择为非 light 时重复刷新页面切换为 light 问题

### DIFF
--- a/src/pages/components/editor.tsx
+++ b/src/pages/components/editor.tsx
@@ -17,6 +17,7 @@ import { LangList } from '../../locales';
 import { useGlobal } from '../../recoil';
 import type { L7EditorProps } from '../../types';
 import useStyle from './styles';
+import { useUpdateEffect } from 'ahooks';
 
 type EditorProps = L7EditorProps;
 
@@ -26,7 +27,7 @@ export const Editor: React.FC<EditorProps> = (props) => {
   const { theme, mapOptions, setMapOptions, showIndex, locale } = useGlobal();
   const styles = useStyle();
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     if (theme === 'dark') {
       setMapOptions({ ...mapOptions, style: 'dark' });
     } else {


### PR DESCRIPTION
### PR includes

- [x] 修复主题选择为非 light 时重复刷新页面切换为 light 问题

### Screenshot

| Before | After |
| ------ | ----- |
| ❌     | ✅    |
