### PR TITLE
fix: 解决 WGS84 格式下 LayerPopup 添加字段导致位移的问题

### DIFF
--- a/src/components/layer-list/index.tsx
+++ b/src/components/layer-list/index.tsx
@@ -1,11 +1,5 @@
-import type {
-  PolygonLayerProps} from '@antv/larkmap';
-import {
-  LineLayer,
-  PointLayer,
-  PolygonLayer,
-  useScene,
-} from '@antv/larkmap';
+import type { PolygonLayerProps } from '@antv/larkmap';
+import { LineLayer, PointLayer, PolygonLayer, useScene } from '@antv/larkmap';
 import type { Feature } from '@turf/turf';
 import { useAsyncEffect } from 'ahooks';
 import Color from 'color';
@@ -33,7 +27,6 @@ export const LayerList: React.FC = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newFeatures, coordConvert, baseMap]);
-
   const [
     pointSource,
     lineSource,

--- a/src/components/layer-popup/index.tsx
+++ b/src/components/layer-popup/index.tsx
@@ -288,8 +288,7 @@ export const LayerPopup: React.FC = () => {
           feature.properties?.[FeatureKey.Index]
         );
       });
-      const revertFeature = revertCoord([feature])[0];
-      features[index] = revertFeature as Feature<
+      features[index] = revertCoord([feature])[0] as Feature<
         Geometry | GeometryCollection,
         object
       >;
@@ -314,8 +313,7 @@ export const LayerPopup: React.FC = () => {
           feature.properties?.[FeatureKey.Index]
         );
       });
-      const revertFeature = revertCoord([feature])[0];
-      features[index] = revertFeature as Feature<
+      features[index] = revertCoord([feature])[0] as Feature<
         Geometry | GeometryCollection,
         object
       >;

--- a/src/components/layer-popup/index.tsx
+++ b/src/components/layer-popup/index.tsx
@@ -29,7 +29,6 @@ import { useDrawHelper } from '../../hooks';
 import { useFeature, useGlobal } from '../../recoil';
 import { getDrawStyle, isCircle, isRect } from '../../utils';
 import { prettierText } from '../../utils/prettier-text';
-// import './index.css';
 import useStyle from './styles';
 
 const { Paragraph } = Typography;
@@ -289,7 +288,11 @@ export const LayerPopup: React.FC = () => {
           feature.properties?.[FeatureKey.Index]
         );
       });
-      features[index] = feature;
+      const revertFeature = revertCoord([feature])[0];
+      features[index] = revertFeature as Feature<
+        Geometry | GeometryCollection,
+        object
+      >;
       saveEditorText(prettierText({ content: featureCollection(features) }));
     }
     setTableClick({ isInput: false, index: null });
@@ -311,7 +314,11 @@ export const LayerPopup: React.FC = () => {
           feature.properties?.[FeatureKey.Index]
         );
       });
-      features[index] = feature;
+      const revertFeature = revertCoord([feature])[0];
+      features[index] = revertFeature as Feature<
+        Geometry | GeometryCollection,
+        object
+      >;
       saveEditorText(prettierText({ content: featureCollection(features) }));
       setAddValue({ label: undefined, value: undefined });
       setAddOpen(!addOpen);


### PR DESCRIPTION
### PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] WGS84 格式下 LayerPopup 添加字段导致位移的问题

### Screenshot

| Before | After |
| ------ | ----- |
| ❌     | ✅    |
